### PR TITLE
Enable python3.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,9 @@ strategy:
     pypy3:
       python.version: 'pypy3'
       tox.env: 'pypy3'
+    Python34:
+      python.version: '3.4'
+      tox.env: 'py35'
     Python35:
       python.version: '3.5'
       tox.env: 'py35'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ strategy:
       tox.env: 'pypy3'
     Python34:
       python.version: '3.4'
-      tox.env: 'py35'
+      tox.env: 'py34'
     Python35:
       python.version: '3.5'
       tox.env: 'py35'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="pytest-subprocess",
-    version="0.1.0",
+    version="0.1.1",
     author="Andrzej Klajnert",
     author_email="python@aklajnert.pl",
     maintainer="Andrzej Klajnert",
@@ -24,7 +24,7 @@ setup(
     description="A plugin to fake subprocess for pytest",
     long_description=read("README.rst"),
     py_modules=["pytest_subprocess"],
-    python_requires=">=3.5",
+    python_requires=">=3.4",
     install_requires=["pytest>=4.0.0"],
     packages=find_packages(exclude=["docs", "tests"]),
     package_data={"pytest_subprocess": ["py.typed", "core.pyi", "fixtures.pyi",]},

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py35,py36,py37,py38,pypy,flake8,mypy,retype
+envlist = py34,py35,py36,py37,py38,pypy,flake8,mypy,retype
 
 [testenv]
 deps = pytest>=4.0

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ ignore = E231,W503
 max-line-length = 89
 
 [mypy]
-python_version = 3.5
+python_version = 3.4
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True


### PR DESCRIPTION
Originally there was no intention of supporting python3.4, but since the tests are passing for it, there is no harm in enabling it in `setup.py`.