### PR TITLE
core: do not append newlines to ouputs unless list/tuple

### DIFF
--- a/pytest_subprocess/core.py
+++ b/pytest_subprocess/core.py
@@ -136,17 +136,18 @@ class FakePopen:
         if isinstance(input, (list, tuple)):
             input = linesep.join(map(self._convert, input))
 
+            # Add trailing newline if data is present.
+            if input:
+                input += linesep
+
         if isinstance(input, str) and not self.text_mode:
             input = input.encode()
 
         if isinstance(input, bytes) and self.text_mode:
             input = input.decode()
 
-        if input:
-            if not input.endswith(linesep):
-                input += linesep
-            if self.text_mode and self.__universal_newlines:
-                input = input.replace("\r\n", "\n")
+        if input and self.__universal_newlines:
+            input = input.replace("\r\n", "\n")
 
         if io_base is not None:
             input = io_base.getvalue() + (input)


### PR DESCRIPTION
Instead of treating all stdout and stderr outputs as string lines
to have newlines, respect the stdout/stderr parameters provided to
register_subprocess().  This allows for more control of the fixture
and allow for binary inputs (and text data with line breaks other
than os.linesep).

Preserve the prior functionality when outputs are a list/tuple. In
this context, it makes sense to treat the inputs as a sequence of
text lines.

Update documentation to show both methods, add test cases for binary
data, and update existing tests that relied on the newline behavior.

Fixes #33

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>