### PR TITLE
Fix subprocess.run() finishes before the configred callback

### DIFF
--- a/pytest_subprocess/core.py
+++ b/pytest_subprocess/core.py
@@ -90,6 +90,9 @@ class FakePopen:
                     callable_output, "stderr", self.stderr
                 )
 
+        if self.__thread is not None:
+            self.__thread.join(timeout)
+
         return (
             self.stdout.getvalue() if self.stdout else None,
             self.stderr.getvalue() if self.stderr else None,


### PR DESCRIPTION
As mentioned in the docs for subprocess' Popen.communicate():

> Wait for process to terminate and set the returncode attribute.

So far FakePopen.communicate() was not waiting for the thread running
the callback to finish, so depending on thread scheduling
subprocess.run() sometimes finished before the configured callback
was fully invoked and returned to the caller. This led to nasty
side-effects and randomness in tests.

With this change Popen.communicate() now waits for the thread calling
the configured callback, so the callback is fully invoked before
subprocess.run() finishes.

It's possible that this change also fixes the flaky test named
test_raise_exception_check_output.