### PR TITLE
Prevent `allow_unregistered()` and `keep_last_process()` from affecting other tests

### DIFF
--- a/changelog.d/bug.816aaaef.entry.yaml
+++ b/changelog.d/bug.816aaaef.entry.yaml
@@ -1,0 +1,6 @@
+message: Prevent `allow_unregistered()` and `keep_last_process()` from affecting other
+  tests.
+pr_ids:
+- '47'
+timestamp: 1626522235
+type: bug

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -38,8 +38,6 @@ def test_documentation(testdir, rst_file):
         "\n\n"
         "@pytest.fixture(autouse=True)\n"
         "def setup():\n"
-        "    pytest_subprocess.core.ProcessDispatcher.allow_unregistered(False)\n"
-        "    pytest_subprocess.core.ProcessDispatcher.keep_last_process(False)\n"
         "    os.chdir(os.path.dirname(__file__))\n\n"
     )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 import pytest
@@ -19,9 +18,6 @@ def get_code_blocks(file_path):
     return [block.astext() for block in code_blocks]
 
 
-@pytest.mark.skipif(
-    sys.version_info <= (3, 5), reason="Examples are for supported Python versions",
-)
 @pytest.mark.parametrize("rst_file", ("docs/index.rst", "README.rst"))
 def test_documentation(testdir, rst_file):
     imports = "\n".join(

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -23,8 +23,6 @@ def setup_fake_popen(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def setup():
-    pytest_subprocess.core.ProcessDispatcher.allow_unregistered(False)
-    pytest_subprocess.core.ProcessDispatcher.keep_last_process(False)
     os.chdir(os.path.dirname(__file__))
 
 


### PR DESCRIPTION
Closes #46 