### PR TITLE
Raise callback exceptions on communicate()

### DIFF
--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -956,7 +956,7 @@ def test_communicate_raises_exceptions_from_callback(fp):
         raise MyException()
 
     fp.register(["test"], callback=callback)
-    
+
     proc = subprocess.Popen("test")
     with pytest.raises(MyException):
         proc.communicate()

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -948,6 +948,19 @@ def test_called_process_waits_for_the_callback_to_finish(fp, tmp_path):
     assert output_file_path.exists()
 
 
+def test_communicate_raises_exceptions_from_callback(fp):
+    class MyException(Exception):
+        pass
+
+    def callback(process):
+        raise MyException()
+
+    fp.register(["test"], callback=callback)
+    with pytest.raises(MyException):
+        p = subprocess.Popen("test")
+        p.communicate()
+
+
 def test_allow_unregistered_cleaning(fp):
     """
     GitHub: #46.

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -956,9 +956,10 @@ def test_communicate_raises_exceptions_from_callback(fp):
         raise MyException()
 
     fp.register(["test"], callback=callback)
+    
+    proc = subprocess.Popen("test")
     with pytest.raises(MyException):
-        p = subprocess.Popen("test")
-        p.communicate()
+        proc.communicate()
 
 
 def test_allow_unregistered_cleaning(fp):


### PR DESCRIPTION
Fixes #92.

> Previously, only `wait()` raised exceptions from the callback thread.
> This commit extends this behavior to `communicate()` in both synchronous
> and async flavours.

I'm not 100% sure if I did this the right way, but it seems to work.