### PR TITLE
feat: add a program matcher

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -305,6 +305,18 @@ if the subprocess command will be called with a string argument.
         assert subprocess.check_call(["my_app", "--help"]) == 0
 
 
+You can also specify just the command name, and have it match any command with
+the same name, regardless of the location. This is accomplished with
+``fake_subprocess.program("name")``.
+
+.. code-block:: python
+
+    def test_any_matching_program(fp):
+        # define a command that can come from anywhere
+        fp.register([fp.program("ls")])
+        assert subprocess.check_call("/bin/ls") == 0
+
+
 Check if process was called
 ---------------------------
 

--- a/pytest_subprocess/fake_popen.py
+++ b/pytest_subprocess/fake_popen.py
@@ -170,6 +170,7 @@ class FakePopen:
             self._write_to_buffer(self.__stdout, stdout)
         stderr = kwargs.get("stderr")
         if stderr == subprocess.STDOUT and self.__stderr:
+            assert self.stdout is not None
             self.stdout = self._prepare_buffer(self.__stderr, self.stdout)
         elif stderr == subprocess.PIPE:
             self.stderr = self._prepare_buffer(self.__stderr)

--- a/pytest_subprocess/fake_process.py
+++ b/pytest_subprocess/fake_process.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from collections import deque
 from typing import Any as AnyType
 from typing import Callable
+from typing import ClassVar
 from typing import DefaultDict
 from typing import Deque
 from typing import Dict
@@ -18,12 +19,14 @@ from .types import COMMAND
 from .types import OPTIONAL_TEXT_OR_ITERABLE
 from .utils import Any
 from .utils import Command
+from .utils import Program
 
 
 class FakeProcess:
     """Main class responsible for process operations"""
 
-    any: Type[Any] = Any
+    any: ClassVar[Type[Any]] = Any
+    program: ClassVar[Type[Program]] = Program
 
     def __init__(self) -> None:
         self.definitions: DefaultDict[Command, Deque[Union[Dict, bool]]] = defaultdict(

--- a/pytest_subprocess/utils.py
+++ b/pytest_subprocess/utils.py
@@ -1,4 +1,7 @@
+import os
+import sys
 import threading
+from pathlib import Path
 from typing import Any as AnyType
 from typing import Iterator
 from typing import List
@@ -127,7 +130,34 @@ class Any:
         self.max: Optional[int] = max
 
     def __str__(self) -> str:
-        return f"Any (min={self.min}, max={self.max})"
+        return f"{self.__class__.__name__} (min={self.min}, max={self.max})"
 
     def __repr__(self) -> str:
         return str(self)
+
+
+class Program:
+    """Specifies the name of the final program to be executed."""
+
+    def __init__(self, program: str) -> None:
+        self.program: str = program
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.program!r})"
+
+    def __eq__(self, other: AnyType) -> bool:
+        if isinstance(other, str):
+            if Path(other).name == self.program:
+                return True
+
+            if sys.platform.startswith("win"):
+                for ext in os.environ.get("PATHEXT", "").split(os.pathsep):
+                    if (
+                        Path(other).name.lower()
+                        == Path(self.program).with_suffix(ext).name.lower()
+                    ):
+                        return True
+        return False
+
+    def __hash__(self) -> int:
+        return hash(self.program)


### PR DESCRIPTION
Closes #100.

This adds `fp.program("name")` to match a program regardless of where it is on the path.

Two possible concerns/changes:

* Should this require that the program directory be in the `PATH`, rather than matching for all directories?
* Should this do case insensitive comparisons on macOS if macOS is set to case insensitive (the default)? Is there some existing handling for this I could leverage, if so?

I also had to tweak the types a bit for mypy 0.99x. I personally like adding mypy to pre-commit and having pre-commit handle pinning and updates.
