### PR TITLE
Remove Python 3.6 from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10', '3.11-dev' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10', '3.11' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/pytest_subprocess/fake_popen.py
+++ b/pytest_subprocess/fake_popen.py
@@ -179,7 +179,7 @@ class FakePopen:
     def _prepare_buffer(
         self,
         input: OPTIONAL_TEXT_OR_ITERABLE,
-        io_base: BUFFER = None,
+        io_base: Optional[BUFFER] = None,
     ) -> Union[io.BytesIO, io.StringIO, asyncio.StreamReader]:
         linesep = self._convert(os.linesep)
 


### PR DESCRIPTION
Python 3.6 reached the end of life, so it is not supported out of the box by GH actions. This PR removes only running CI suite against this python version.