### PR TITLE
ci: update jobs and restore 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,63 +18,33 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.7, 3.8, 3.9, '3.10', '3.11' ]
+        platform: [ ubuntu-20.04, macos-latest, windows-latest ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.8']
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
+      - uses: actions/checkout@v3
+
       - name: Setup Nox
-        uses: aklajnert/setup-nox@v2.0.1
+        uses: wntrblm/nox@2022.11.21
+        with:
+          python-versions: ${{ matrix.python-version }}
       - name: Run tests
-        if: matrix.python-version != '3.11-dev'
         run: |
-          nox -s tests-${{ matrix.python-version }} --error-on-missing-interpreters
-        env:
-          PLATFORM: ${{ matrix.platform }}
-      - name: Run tests 3.11
-        if: matrix.python-version == '3.11-dev'
-        run: |
-          nox -s tests-3.11 --error-on-missing-interpreters
+          nox -s tests-${{ matrix.python-version }}
         env:
           PLATFORM: ${{ matrix.platform }}
       - name: Update coverage
+        if: matrix.python-version != 'pypy3.8'
         uses: codecov/codecov-action@v1
 
-  test-pypy:
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      max-parallel: 4
-      matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ pypy-3.7 ]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-      - name: Setup Nox
-        uses: aklajnert/setup-nox@v2.0.1
-      - name: Run tests
-        run: |
-          nox -s tests-pypy3 --error-on-missing-interpreters
-        env:
-          PLATFORM: ${{ matrix.platform }}
 
   mypy:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Nox
-        uses: aklajnert/setup-nox@v2.0.1
+        uses: wntrblm/nox@2022.11.21
       - name: Run mypy
         run: |
           nox -s mypy
@@ -82,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Nox
-        uses: aklajnert/setup-nox@v2.0.1
+        uses: wntrblm/nox@2022.11.21
       - name: Run flake8
         run: |
           nox -s flake8
@@ -92,9 +62,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Nox
-        uses: aklajnert/setup-nox@v2.0.1
+        uses: wntrblm/nox@2022.11.21
       - name: Build docs
         run: |
           nox -s docs

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8"])
 def tests(session):
     session.install(".[test]")
     session.run("coverage", "run", "-m", "pytest", "-v")
@@ -21,7 +21,8 @@ def mypy(session):
     session.run("mypy", "tests/test_typing.py", "--config-file=setup.cfg")
 
 
-@nox.session
+# Note sphinx-napoleon uses deprecated renames removed in 3.10
+@nox.session(python="3.9")
 def docs(session):
     session.install(".[docs]")
     session.run("sphinx-build", "-b", "html", "docs", "docs/_build", "-v", "-W")


### PR DESCRIPTION
This restores 3.6 (temporarily till the next release? etc.), switches to the official nox action, and updates the checkout action.
