### PR TITLE
fix: match os.PathLike too

### DIFF
--- a/pytest_subprocess/types.py
+++ b/pytest_subprocess/types.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import os
 from typing import Sequence
 from typing import Union
 
@@ -14,5 +15,5 @@ OPTIONAL_TEXT_OR_ITERABLE = Union[
     Sequence[Union[str, bytes]],
 ]
 BUFFER = Union[io.BytesIO, io.StringIO, asyncio.StreamReader]
-ARGUMENT = Union[str, Any]
+ARGUMENT = Union[str, Any, os.PathLike]
 COMMAND = Union[Sequence[ARGUMENT], str, Command]

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -14,8 +14,18 @@ from pytest_subprocess.fake_popen import FakePopen
 
 PYTHON = sys.executable
 
+win_path_skip = pytest.mark.skipif(
+    sys.platform.startswith("win") and sys.version_info < (3, 8),
+    reason="Path in subprocess not supported before 3.8 on Windows",
+)
 path_or_str = pytest.mark.parametrize(
-    "rtype,ptype", [(str, str), (Path, str), (str, Path), (Path, Path)]
+    "rtype,ptype",
+    [
+        pytest.param(str, str, id="str"),
+        pytest.param(Path, str, marks=win_path_skip, id="path,str"),
+        pytest.param(str, Path, marks=win_path_skip, id="str,path"),
+        pytest.param(Path, Path, marks=win_path_skip, id="path"),
+    ],
 )
 
 

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -5,6 +5,7 @@ import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -41,6 +42,16 @@ def test_completedprocess_args(fp, cmd):
 
     assert proc.args == cmd
     assert isinstance(proc.args, type(cmd))
+
+
+@pytest.mark.parametrize("p1,p2", [(Path, str), (str, Path), (Path, Path)])
+def test_completedprocess_args_path(fp, p1, p2):
+    fp.register([p1("cmd")])
+
+    proc = subprocess.run([p2("cmd")], check=True)
+
+    assert proc.args == [p2("cmd")]
+    assert isinstance(proc.args[0], p2)
 
 
 @pytest.mark.parametrize("cmd", [("cmd"), ["cmd"]])


### PR DESCRIPTION
Starting in Python 3.8 (and older versions on UNIX), subprocess accepts `os.PathLike` arguments. This adds support for that in `fp.register` too.

Closes #101.

