### PR TITLE
fix: add missing Program type in ARGUMENT type union

### DIFF
--- a/pytest_subprocess/types.py
+++ b/pytest_subprocess/types.py
@@ -4,7 +4,9 @@ import os
 from typing import Sequence
 from typing import Union
 
-from .utils import Any, Command, Program
+from .utils import Any
+from .utils import Command
+from .utils import Program
 
 
 OPTIONAL_TEXT = Union[str, bytes, None]

--- a/pytest_subprocess/types.py
+++ b/pytest_subprocess/types.py
@@ -4,8 +4,8 @@ import os
 from typing import Sequence
 from typing import Union
 
-from .utils import Any
-from .utils import Command
+from .utils import Any, Command, Program
+
 
 OPTIONAL_TEXT = Union[str, bytes, None]
 OPTIONAL_TEXT_OR_ITERABLE = Union[
@@ -15,5 +15,5 @@ OPTIONAL_TEXT_OR_ITERABLE = Union[
     Sequence[Union[str, bytes]],
 ]
 BUFFER = Union[io.BytesIO, io.StringIO, asyncio.StreamReader]
-ARGUMENT = Union[str, Any, os.PathLike]
+ARGUMENT = Union[str, Any, os.PathLike, Program]
 COMMAND = Union[Sequence[ARGUMENT], str, Command]


### PR DESCRIPTION
Great work with this project!

I was hit by an error from mypy when trying to do something like the below which functionally seems to work perfectly fine
```
fp.register([fp.program("nameofbinary")])
```

The mypy error reads: `error: List item 0 has incompatible type "Program"; expected "str | pytest_subprocess.utils.Any | PathLike[Any]"  [list-item]`

The changes in this PR was enough to fix the error for me.