### PR TITLE
Include tests (and docs) and sdist correctly, and stop installing them to site-packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,10 @@
 include LICENSE
 include README.rst
 include HISTORY.rst
+include pytest.ini
+
+recursive-include docs *
+recursive-include tests *.py
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     },
     description="A plugin to fake subprocess for pytest",
     long_description=read("README.rst") + "\n" + read("HISTORY.rst"),
-    py_modules=["pytest_subprocess"],
     python_requires=">=3.6",
     install_requires=requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "changelogd",
         ],
     },
-    packages=find_packages(exclude=["docs"]),
+    packages=find_packages(exclude=["docs", "tests"]),
     package_data={"pytest_subprocess": ["py.typed"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
1. Revert the change that caused `tests` to be installed as a top-level package.
2. Include docs, tests and associated files in sdist correctly.
3. Remove stray `py_modules` from `setup.py`.