### PR TITLE
Infinite timeout when reading stdout with callback

### DIFF
--- a/pytest_subprocess/fake_popen.py
+++ b/pytest_subprocess/fake_popen.py
@@ -11,7 +11,8 @@ import sys
 import time
 from asyncio import Task
 from functools import partial
-from typing import Any as AnyType, Awaitable
+from typing import Any as AnyType
+from typing import Awaitable
 from typing import Callable
 from typing import Dict
 from typing import IO


### PR DESCRIPTION
* get rid of using thread in async Popen() as it causes thread.join() to hang indefinitely