### PR TITLE
Infinite timeout when reading stdout with callback

### DIFF
--- a/changelog.d/bug.75e40e8c.entry.yaml
+++ b/changelog.d/bug.75e40e8c.entry.yaml
@@ -1,0 +1,6 @@
+message: Get rid of using thread in AsyncFakePopen as it causes thread.join() to hang
+  indefinitely.
+pr_ids:
+- '169'
+timestamp: 1727847419
+type: bug

--- a/pytest_subprocess/fake_popen.py
+++ b/pytest_subprocess/fake_popen.py
@@ -395,4 +395,6 @@ class AsyncFakePopen(FakePopen):
             await asyncio.wait_for(self._run_callback_in_executor(), timeout=timeout)
         else:
             await self._run_callback_in_executor()
-        self._finish_process()
+        if self.returncode is None:
+            self.returncode = self._returncode
+        self._finalize_streams()

--- a/pytest_subprocess/process_dispatcher.py
+++ b/pytest_subprocess/process_dispatcher.py
@@ -162,7 +162,7 @@ class ProcessDispatcher:
         result = cls._prepare_instance(AsyncFakePopen, command, kwargs, process)
         if not isinstance(result, AsyncFakePopen):
             raise exceptions.PluginInternalError
-        result.run_thread()
+        result.evaluate()
         return result
 
     @classmethod


### PR DESCRIPTION
* get rid of using thread in AsyncFakePopen as it causes thread.join() to hang indefinitely