### PR TITLE
Fix stdin not respecting text mode when text=True or encoding is set.

### DIFF
--- a/changelog.d/bug.8db267c7.entry.yaml
+++ b/changelog.d/bug.8db267c7.entry.yaml
@@ -1,0 +1,5 @@
+message: Fix stdin not respecting text mode when text=True or encoding is set.
+pr_ids:
+- '205'
+timestamp: 1778312802
+type: bug

--- a/pytest_subprocess/fake_popen.py
+++ b/pytest_subprocess/fake_popen.py
@@ -170,10 +170,6 @@ class FakePopen:
         self.__kwargs = self.safe_copy(kwargs)
         self.__universal_newlines = kwargs.get("universal_newlines", None)
 
-        stdin = kwargs.get("stdin")
-        if stdin == subprocess.PIPE:
-            self.stdin = self._get_empty_buffer(False)
-
         text = kwargs.get("text", None)
         encoding = kwargs.get("encoding", None)
         errors = kwargs.get("errors", None)
@@ -182,6 +178,10 @@ class FakePopen:
             raise TypeError("__init__() got an unexpected keyword argument 'text'")
 
         self.text_mode = bool(text or self.__universal_newlines or encoding or errors)
+
+        stdin = kwargs.get("stdin")
+        if stdin == subprocess.PIPE:
+            self.stdin = self._get_empty_buffer(self.text_mode)
 
         # validation taken from the real subprocess
         if (

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,5 +1,6 @@
 import contextlib
 import getpass
+import io
 import os
 import platform
 import signal
@@ -1349,6 +1350,62 @@ def test_stdin_pipe(fp):
     process.stdin.close()
     with pytest.raises(ValueError):
         process.stdin.write(b"more data")
+
+
+def test_stdin_pipe_text_mode(fp):
+    """
+    Test that stdin is a StringIO (text) buffer when using
+    subprocess.PIPE with text=True.
+
+    From GitHub #204
+    """
+    fp.register(["my-command"], stdout="hello\n")
+
+    process = subprocess.Popen(
+        ["my-command"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert process.stdin is not None
+    assert isinstance(process.stdin, io.StringIO)
+    assert process.stdin.writable()
+
+    # Should accept str, not bytes, in text mode.
+    process.stdin.write("some input")
+    process.stdin.flush()
+
+    process.stdin.seek(0)
+    assert process.stdin.read() == "some input"
+
+    process.stdin.close()
+    with pytest.raises(ValueError):
+        process.stdin.write("more data")
+
+
+def test_stdin_pipe_encoding_mode(fp):
+    """
+    Test that stdin is a StringIO (text) buffer when
+    using subprocess.PIPE with encoding set.
+
+    From GitHub #204
+    """
+    fp.register(["my-command"])
+
+    process = subprocess.Popen(
+        ["my-command"],
+        stdin=subprocess.PIPE,
+        encoding="utf-8",
+    )
+
+    assert process.stdin is not None
+    assert isinstance(process.stdin, io.StringIO)
+    assert process.stdin.writable()
+
+    process.stdin.write("some input")
+    process.stdin.close()
 
 
 def test_stdout_stderr_as_file_bug(fp):


### PR DESCRIPTION
Closes #204 