### PR TITLE
Add fp.regex() for regex-based command argument matching.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -333,7 +333,9 @@ expression using ``fp.regex()``:
         )
 
         # Both calls are matched, even though the paths differ.
-        subprocess.run(["cmake", "-S/tmp/generated_data", "-B/tmp/build_1234"])
+        subprocess.run(
+            ["cmake", "-S/tmp/generated_data", "-B/tmp/build_1234"]
+        )
         subprocess.run(["cmake", "-S/other/source", "-B/other/build_5678"])
 
         # This would raise ProcessNotRegisteredError — different subcommand:
@@ -345,9 +347,10 @@ expression using ``fp.regex()``:
 
     import re
 
+
     def test_case_insensitive(fp):
         fp.register(["git", fp.regex(r"commit", re.IGNORECASE)])
-        subprocess.run(["git", "COMMIT"])   # matches
+        subprocess.run(["git", "COMMIT"])  # matches
 
 .. note::
    ``fp.regex()`` uses :func:`re.fullmatch`, so the pattern must cover the

--- a/README.rst
+++ b/README.rst
@@ -316,6 +316,45 @@ the same name, regardless of the location. This is accomplished with
         assert subprocess.check_call(sys.executable) == 0
 
 
+Regex argument matching
+-----------------------
+
+When a command argument has a predictable *structure* but an unpredictable
+*value* (e.g. a path determined at runtime), you can match it with a regular
+expression using ``fp.regex()``:
+
+.. code-block:: python
+
+    def test_cmake_varying_paths(fp):
+        # Register once; the pattern matches any -S<path> and -B<path> argument.
+        fp.register(
+            ["cmake", fp.regex(r"-S.+"), fp.regex(r"-B.+")],
+            occurrences=2,
+        )
+
+        # Both calls are matched, even though the paths differ.
+        subprocess.run(["cmake", "-S/tmp/generated_data", "-B/tmp/build_1234"])
+        subprocess.run(["cmake", "-S/other/source", "-B/other/build_5678"])
+
+        # This would raise ProcessNotRegisteredError — different subcommand:
+        # subprocess.run(["cmake", "--build", "/tmp/build_1234"])
+
+``fp.regex()`` accepts an optional second argument for :mod:`re` flags:
+
+.. code-block:: python
+
+    import re
+
+    def test_case_insensitive(fp):
+        fp.register(["git", fp.regex(r"commit", re.IGNORECASE)])
+        subprocess.run(["git", "COMMIT"])   # matches
+
+.. note::
+   ``fp.regex()`` uses :func:`re.fullmatch`, so the pattern must cover the
+   **entire** argument string.  Use ``.*`` at the start or end if you need
+   partial matching.
+
+
 Check if process was called
 ---------------------------
 

--- a/changelog.d/feature.b8e16708.entry.yaml
+++ b/changelog.d/feature.b8e16708.entry.yaml
@@ -1,0 +1,5 @@
+message: Add fp.regex() for regex-based command argument matching.
+pr_ids:
+- '206'
+timestamp: 1778328927
+type: feature

--- a/pytest_subprocess/fake_process.py
+++ b/pytest_subprocess/fake_process.py
@@ -21,6 +21,7 @@ from .types import OPTIONAL_TEXT_OR_ITERABLE
 from .utils import Any
 from .utils import Command
 from .utils import Program
+from .utils import Regex
 
 
 class FakeProcess:
@@ -28,6 +29,7 @@ class FakeProcess:
 
     any: ClassVar[Type[Any]] = Any
     program: ClassVar[Type[Program]] = Program
+    regex: ClassVar[Type[Regex]] = Regex
 
     def __init__(self) -> None:
         self.definitions: DefaultDict[Command, Deque[Union[Dict, bool]]] = defaultdict(

--- a/pytest_subprocess/utils.py
+++ b/pytest_subprocess/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shlex
 import sys
 import threading
@@ -15,7 +16,7 @@ from typing import Union
 if TYPE_CHECKING:
     from .types import COMMAND
 
-ARGUMENT = Union[str, "Any", os.PathLike, "Program"]
+ARGUMENT = Union[str, "Any", "Regex", os.PathLike, "Program"]
 
 
 class Thread(threading.Thread):
@@ -189,3 +190,54 @@ class Program:
 
     def __hash__(self) -> int:
         return hash(self.program)
+
+
+class Regex:
+    """Match a single command argument against a regular expression.
+
+    Uses :func:`re.fullmatch`, so the pattern must cover the *entire* argument
+    string.  Use ``.*`` at the start or end if partial matching is desired.
+
+    Example::
+
+        def test_cmake_varying_paths(fp):
+            fp.register(["cmake", fp.regex(r"-S.+"), fp.regex(r"-B.+")])
+
+            # All of these would match:
+            subprocess.run(["cmake", "-S/tmp/src", "-B/tmp/build"])
+            subprocess.run(["cmake", "-S/other/src", "-B/other/build"])
+
+            # This would NOT match (wrong argument order or missing args):
+            # subprocess.run(["cmake", "-B/tmp/build", "-S/tmp/src"])
+
+    Args:
+        pattern: Regular expression pattern to match against.
+        flags: Optional :mod:`re` flags (e.g. ``re.IGNORECASE``).
+    """
+
+    def __init__(self, pattern: str, flags: int = 0) -> None:
+        self._compiled = re.compile(pattern, flags)
+
+    @property
+    def pattern(self) -> str:
+        """The original pattern string."""
+        return self._compiled.pattern
+
+    @property
+    def flags(self) -> int:
+        """The compiled regex flags."""
+        return self._compiled.flags
+
+    def __eq__(self, other: AnyType) -> bool:
+        if isinstance(other, str):
+            return bool(self._compiled.fullmatch(other))
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash((self._compiled.pattern, self._compiled.flags))
+
+    def __repr__(self) -> str:
+        return f"Regex({self._compiled.pattern!r})"
+
+    def __str__(self) -> str:
+        return repr(self)

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1458,3 +1458,91 @@ def test_imported_popen_is_patched(fp):
 
     assert process.returncode == 0
     assert out == b"\x00"
+
+
+# ---------------------------------------------------------------------------
+# Regex command matching – issue #154
+# ---------------------------------------------------------------------------
+
+
+def test_regex_matches_varying_argument(fp):
+    """
+    fp.regex() must match a single command argument against a regex pattern,
+    allowing commands with variable argument values to be registered once.
+    """
+    fp.register(["cmake", fp.regex(r"-S.+"), fp.regex(r"-B.+")], occurrences=2)
+
+    # Both calls use the same registration; argument values differ.
+    proc1 = subprocess.run(["cmake", "-S/tmp/source1", "-B/tmp/build1"])
+    proc2 = subprocess.run(["cmake", "-S/other/source", "-B/other/build"])
+
+    assert proc1.returncode == 0
+    assert proc2.returncode == 0
+
+
+def test_regex_does_not_match_wrong_argument(fp):
+    """
+    Commands whose arguments do NOT match the registered regex pattern must
+    raise ProcessNotRegisteredError, not silently succeed.
+    """
+    fp.register(["cmake", fp.regex(r"-S.+"), fp.regex(r"-B.+")])
+
+    # Wrong subcommand — does not match the -S/-B pattern.
+    with pytest.raises(fp.exceptions.ProcessNotRegisteredError):
+        subprocess.run(["cmake", "--build", "/tmp/build"])
+
+
+def test_regex_case_insensitive_flag(fp):
+    """
+    fp.regex() must accept re module flags such as re.IGNORECASE.
+    """
+    import re
+
+    fp.register(["git", fp.regex(r"commit", re.IGNORECASE)], stdout="sha: abc123\n")
+
+    # Exact case
+    proc1 = subprocess.run(["git", "commit"], capture_output=True)
+    assert proc1.stdout == b"sha: abc123\n"
+
+    # Different case
+    fp.register(["git", fp.regex(r"commit", re.IGNORECASE)], stdout="sha: abc123\n")
+    proc2 = subprocess.run(["git", "COMMIT"], capture_output=True)
+    assert proc2.stdout == b"sha: abc123\n"
+
+
+def test_regex_fullmatch_semantics(fp):
+    """
+    fp.regex() uses fullmatch: the pattern must cover the *entire* argument
+    string.  A pattern that only matches a substring must NOT match.
+    """
+    # "-S" alone does not fullmatch "-S/some/path" (pattern too short)
+    fp.register(["cmake", fp.regex(r"-S"), fp.regex(r"-B")])
+    with pytest.raises(fp.exceptions.ProcessNotRegisteredError):
+        # "-S/tmp/source" does not fullmatch the pattern "-S" (no extra chars)
+        subprocess.run(["cmake", "-S/tmp/source", "-B/tmp/build"])
+
+
+def test_regex_repr(fp):
+    """
+    fp.regex() instances have a helpful repr for debugging.
+    """
+    r = fp.regex(r"-S.+")
+    assert "-S.+" in repr(r)
+
+
+def test_regex_combined_with_any(fp):
+    """
+    fp.regex() can be combined freely with fp.any() and exact strings in
+    the same command registration.
+    """
+    # Exact "cmake", then any number of arguments matching the -D prefix
+    fp.register(
+        ["cmake", fp.regex(r"-D.+=.+"), fp.any()],
+        stdout="configured\n",
+    )
+
+    proc = subprocess.run(
+        ["cmake", "-DCMAKE_BUILD_TYPE=Release", "-S/tmp/src", "-B/tmp/build"],
+        capture_output=True,
+    )
+    assert proc.stdout == b"configured\n"


### PR DESCRIPTION
Closes #154